### PR TITLE
Fix by using empty object instead of undefined

### DIFF
--- a/lib/one.js
+++ b/lib/one.js
@@ -38,7 +38,7 @@ exports.init = function (gulp, options) {
         connectPort: getPort(0),
         browserSyncPort: getPort(1),
         browserSyncUiPort: getPort(2),
-        browserSyncHttps: undefined,
+        browserSyncHttps: {},
         weinrePort: getPort(3),
         injectWeinreSnippet: false,
         bindHost: 'localhost'


### PR DESCRIPTION
because _.deepExtend cannot deal with undefined vs object